### PR TITLE
Start using `octoprint serve`

### DIFF
--- a/app/start.sh
+++ b/app/start.sh
@@ -11,4 +11,4 @@ cd /usr/src/app/mjpg-streamer/mjpg-streamer-experimental/ \
   && ./mjpg_streamer -i "./input_uvc.so -y" -o "./output_http.so"  &
 
 # start Octoprint
-octoprint --iknowwhatimdoing --port=5000 --basedir /data
+octoprint serve --iknowwhatimdoing --port=5000 --basedir /data


### PR DESCRIPTION
> Starting the server via "octoprint" is deprecated, please use "octoprint serve" from now on.