### PR TITLE
Update setup

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,25 +1,30 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-debian:jessie
+FROM balenalib/%%RESIN_MACHINE_NAME%%-debian:stretch
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-	python-pip \
-	python-dev \
-	git \
-	build-essential \
-	libav-tools \
-	avrdude \
-	curl \
-	subversion \
-	libjpeg8-dev \
-	imagemagick \
-	libav-tools \
-	cmake \
-	haproxy \
-  && apt-get clean \
-  && rm -rf /tmp/* /var/tmp/*  \
-  && rm -rf /var/lib/apt/lists/*
+RUN install_packages \
+  python-pip \
+  python-dev \
+  python-imaging \
+  git \
+  build-essential \
+  libav-tools \
+  avrdude \
+  uvcdynctrl \
+  guvcview \
+  curl \
+  subversion \
+  libjpeg8-dev \
+  imagemagick \
+  libav-tools \
+  cmake \
+  libraspberrypi-bin \
+  libraspberrypi-dev \
+  ffmpeg \
+  haproxy
 
 # Enable haproxy
 RUN echo 'ENABLED=1' >> /etc/default/haproxy
+
+RUN ln -s -T /usr/include/freetype2/ /usr/include/freetype
 
 # Deploy haproxy config
 COPY ./Dockerbin/haproxy.cfg /etc/haproxy/haproxy.cfg
@@ -29,18 +34,31 @@ WORKDIR /usr/src/app
 
 # Install Octoprint from source
 RUN git clone https://github.com/foosel/OctoPrint.git ./octoprint \
-  && cd /usr/src/app/octoprint && pip install --upgrade pip && pip install setuptools \
+#  && cd /usr/src/app/octoprint && pip install --upgrade pip \
+  && pip install setuptools \
   && cd /usr/src/app/octoprint && pip install -r requirements.txt && python setup.py install \
   && cd /usr/src/app/octoprint && pip install https://github.com/BillyBlaze/OctoPrint-TouchUI/archive/master.zip \
 	&& cd /usr/src/app/octoprint && pip install https://github.com/marian42/octoprint-preheat/archive/master.zip \
 	&& cd /usr/src/app/octoprint && pip install "https://github.com/OctoPrint/OctoPrint-DisplayProgress/archive/master.zip" \
-	&& cd /usr/src/app/octoprint && pip install https://github.com/malnvenshorn/OctoPrint-CostEstimation/archive/master.zip
+	&& cd /usr/src/app/octoprint && pip install https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/archive/master.zip \
+  && cd /usr/src/app/octoprint && pip install "https://github.com/jneilliii/OctoPrint-FloatingNavbar/archive/master.zip" \
+  && cd /usr/src/app/octoprint && pip install "https://github.com/imrahil/OctoPrint-NavbarTemp/archive/master.zip" \
+  && cd /usr/src/app/octoprint && pip install "https://github.com/ntoff/OctoPrint-Estop/archive/master.zip" \
+  && cd /usr/src/app/octoprint && pip install "https://github.com/paukstelis/OctoPrint-Cancelobject/archive/master.zip" \
+  && cd /usr/src/app/octoprint && pip install "https://github.com/FormerLurker/Octolapse/archive/v0.3.4.zip"
+
+# Build mjpg_streamer
+RUN git clone https://github.com/jacksonliam/mjpg-streamer.git ./mjpg-streamer \
+  && cd mjpg-streamer/mjpg-streamer-experimental && make && make install
 
 # Move app to filesystem
 COPY ./app ./
 
 ## uncomment if you want systemd
 ENV INITSYSTEM on
+
+# Enable udevd so that plugged dynamic hardware devices show up in our container.
+ENV UDEV=1
 
 # Start app
 CMD ["bash", "/usr/src/app/start.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM balenalib/%%RESIN_MACHINE_NAME%%-debian:stretch
 
-RUN install_packages \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   python-pip \
   python-dev \
   python-imaging \
@@ -19,7 +19,10 @@ RUN install_packages \
   libraspberrypi-bin \
   libraspberrypi-dev \
   ffmpeg \
-  haproxy
+  haproxy \
+  && apt-get clean \
+  && rm -rf /tmp/* /var/tmp/*  \
+  && rm -rf /var/lib/apt/lists/*
 
 # Enable haproxy
 RUN echo 'ENABLED=1' >> /etc/default/haproxy
@@ -34,12 +37,12 @@ WORKDIR /usr/src/app
 
 # Install Octoprint from source
 RUN git clone https://github.com/foosel/OctoPrint.git ./octoprint \
-#  && cd /usr/src/app/octoprint && pip install --upgrade pip \
-  && pip install setuptools \
+  && pip install setuptools wheel --upgrade \
   && cd /usr/src/app/octoprint && pip install -r requirements.txt && python setup.py install \
   && cd /usr/src/app/octoprint && pip install https://github.com/BillyBlaze/OctoPrint-TouchUI/archive/master.zip \
 	&& cd /usr/src/app/octoprint && pip install https://github.com/marian42/octoprint-preheat/archive/master.zip \
 	&& cd /usr/src/app/octoprint && pip install "https://github.com/OctoPrint/OctoPrint-DisplayProgress/archive/master.zip" \
+  && cd /usr/src/app/octoprint && pip install https://github.com/malnvenshorn/OctoPrint-CostEstimation/archive/master.zip \
 	&& cd /usr/src/app/octoprint && pip install https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/archive/master.zip \
   && cd /usr/src/app/octoprint && pip install "https://github.com/jneilliii/OctoPrint-FloatingNavbar/archive/master.zip" \
   && cd /usr/src/app/octoprint && pip install "https://github.com/imrahil/OctoPrint-NavbarTemp/archive/master.zip" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,28 +1,28 @@
 FROM balenalib/%%RESIN_MACHINE_NAME%%-debian:stretch
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  python-pip \
-  python-dev \
-  python-imaging \
-  git \
-  build-essential \
-  libav-tools \
-  avrdude \
-  uvcdynctrl \
-  guvcview \
-  curl \
-  subversion \
-  libjpeg8-dev \
-  imagemagick \
-  libav-tools \
-  cmake \
-  libraspberrypi-bin \
-  libraspberrypi-dev \
-  ffmpeg \
-  haproxy \
-  && apt-get clean \
-  && rm -rf /tmp/* /var/tmp/*  \
-  && rm -rf /var/lib/apt/lists/*
+    python-pip \
+    python-dev \
+    python-imaging \
+    git \
+    build-essential \
+    libav-tools \
+    avrdude \
+    uvcdynctrl \
+    guvcview \
+    curl \
+    subversion \
+    libjpeg8-dev \
+    imagemagick \
+    libav-tools \
+    cmake \
+    libraspberrypi-bin \
+    libraspberrypi-dev \
+    ffmpeg \
+    haproxy \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/*  \
+    && rm -rf /var/lib/apt/lists/*
 
 # Enable haproxy
 RUN echo 'ENABLED=1' >> /etc/default/haproxy
@@ -38,22 +38,22 @@ WORKDIR /usr/src/app
 
 # Install Octoprint from source
 RUN git clone https://github.com/foosel/OctoPrint.git ./octoprint \
-  && cd /usr/src/app/octoprint && pip install setuptools wheel --upgrade \
-  && cd /usr/src/app/octoprint && pip install -r requirements.txt && python setup.py install \
-  && cd /usr/src/app/octoprint && pip install https://github.com/BillyBlaze/OctoPrint-TouchUI/archive/master.zip \
-	&& cd /usr/src/app/octoprint && pip install https://github.com/marian42/octoprint-preheat/archive/master.zip \
-	&& cd /usr/src/app/octoprint && pip install "https://github.com/OctoPrint/OctoPrint-DisplayProgress/archive/master.zip" \
-  && cd /usr/src/app/octoprint && pip install https://github.com/malnvenshorn/OctoPrint-CostEstimation/archive/master.zip \
-	&& cd /usr/src/app/octoprint && pip install https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/archive/master.zip \
-  && cd /usr/src/app/octoprint && pip install "https://github.com/jneilliii/OctoPrint-FloatingNavbar/archive/master.zip" \
-  && cd /usr/src/app/octoprint && pip install "https://github.com/imrahil/OctoPrint-NavbarTemp/archive/master.zip" \
-  && cd /usr/src/app/octoprint && pip install "https://github.com/ntoff/OctoPrint-Estop/archive/master.zip" \
-  && cd /usr/src/app/octoprint && pip install "https://github.com/paukstelis/OctoPrint-Cancelobject/archive/master.zip" \
-  && cd /usr/src/app/octoprint && pip install "https://github.com/FormerLurker/Octolapse/archive/v0.3.4.zip"
+    && cd /usr/src/app/octoprint && pip install setuptools wheel --upgrade \
+    && cd /usr/src/app/octoprint && pip install -r requirements.txt && python setup.py install \
+    && cd /usr/src/app/octoprint && pip install https://github.com/BillyBlaze/OctoPrint-TouchUI/archive/master.zip \
+    && cd /usr/src/app/octoprint && pip install https://github.com/marian42/octoprint-preheat/archive/master.zip \
+    && cd /usr/src/app/octoprint && pip install "https://github.com/OctoPrint/OctoPrint-DisplayProgress/archive/master.zip" \
+    && cd /usr/src/app/octoprint && pip install https://github.com/malnvenshorn/OctoPrint-CostEstimation/archive/master.zip \
+    && cd /usr/src/app/octoprint && pip install https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/archive/master.zip \
+    && cd /usr/src/app/octoprint && pip install "https://github.com/jneilliii/OctoPrint-FloatingNavbar/archive/master.zip" \
+    && cd /usr/src/app/octoprint && pip install "https://github.com/imrahil/OctoPrint-NavbarTemp/archive/master.zip" \
+    && cd /usr/src/app/octoprint && pip install "https://github.com/ntoff/OctoPrint-Estop/archive/master.zip" \
+    && cd /usr/src/app/octoprint && pip install "https://github.com/paukstelis/OctoPrint-Cancelobject/archive/master.zip" \
+    && cd /usr/src/app/octoprint && pip install "https://github.com/FormerLurker/Octolapse/archive/v0.3.4.zip"
 
 # Build mjpg_streamer
 RUN git clone https://github.com/jacksonliam/mjpg-streamer.git ./mjpg-streamer \
-  && cd mjpg-streamer/mjpg-streamer-experimental && make && make install
+    && cd mjpg-streamer/mjpg-streamer-experimental && make && make install
 
 # Move app to filesystem
 COPY ./app ./

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Enable haproxy
 RUN echo 'ENABLED=1' >> /etc/default/haproxy
 
+# Symlink to fix installing Octolapse
 RUN ln -s -T /usr/include/freetype2/ /usr/include/freetype
 
 # Deploy haproxy config
@@ -37,7 +38,7 @@ WORKDIR /usr/src/app
 
 # Install Octoprint from source
 RUN git clone https://github.com/foosel/OctoPrint.git ./octoprint \
-  && pip install setuptools wheel --upgrade \
+  && cd /usr/src/app/octoprint && pip install setuptools wheel --upgrade \
   && cd /usr/src/app/octoprint && pip install -r requirements.txt && python setup.py install \
   && cd /usr/src/app/octoprint && pip install https://github.com/BillyBlaze/OctoPrint-TouchUI/archive/master.zip \
 	&& cd /usr/src/app/octoprint && pip install https://github.com/marian42/octoprint-preheat/archive/master.zip \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bbalena-octoprint
+# balena-octoprint
 remotely control your 3d-printer with [octoprint](https://github.com/foosel/OctoPrint) and Balena !
 
 **octoprint is exposed on port 80 which can be remotely accessible via Balena [public URL](https://www.balena.io/docs/learn/manage/actions/#enable-public-device-url) feature**

--- a/README.md
+++ b/README.md
@@ -1,15 +1,30 @@
-# resin-octoprint
-remotely control your 3d-printer with [octoprint](https://github.com/foosel/OctoPrint) and resin.io !
+# bbalena-octoprint
+remotely control your 3d-printer with [octoprint](https://github.com/foosel/OctoPrint) and Balena !
 
-**octoprint is exposed on port 80 which can be remotely accessible via resin.io [public URL](https://docs.resin.io/management/devices/#enable-public-device-url) feature**
+**octoprint is exposed on port 80 which can be remotely accessible via Balena [public URL](https://www.balena.io/docs/learn/manage/actions/#enable-public-device-url) feature**
+
+## Features
+
+- Latest version of Octoprint
+- The following Octoprint plugins are added:
+  - [TouchUI](https://plugins.octoprint.org/plugins/touchui/)
+  - [Preheat](https://plugins.octoprint.org/plugins/preheat/)
+  - [DisplayProgress](https://plugins.octoprint.org/plugins/displayprogress/)
+  - [BedLevelVisualizer](https://plugins.octoprint.org/plugins/bedlevelvisualizer/)
+  - [Floating Navbar](https://plugins.octoprint.org/plugins/floatingnavbar/)
+  - [Navbar Temperature](https://plugins.octoprint.org/plugins/navbartemp/)
+  - [Emergency Stop Button](https://plugins.octoprint.org/plugins/estop/)
+  - [Cancel Object](https://plugins.octoprint.org/plugins/cancelobject/)
+  - [Octolapse](https://plugins.octoprint.org/plugins/octolapse/) (version 0.3.4)
+- A MJPG streamer that is accessible via http://<public-url>/webcam/
 
 ## Getting started
 
-- Sign up on [resin.io](https://dashboard.resin.io/signup)
-- go through the [getting started guide](http://docs.resin.io/raspberrypi/nodejs/getting-started/) and create a new application
+- Sign up on [balena-cloud.io](https://dashboard.balena-cloud.com/signup)
+- go through the [getting started guide](https://www.balena.io/docs/learn/getting-started/raspberry-pi/nodejs/) and create a new application
 - clone this repository to your local workspace
-- add the _resin remote_ to your local workspace using the useful shortcut in the dashboard UI
-- `git push resin master`
+- add the _balena remote_ to your local workspace using the useful shortcut in the dashboard UI
+- `git push balena master`
 - see the magic happening, your device is getting updated Over-The-Air!
 
 ## Configure via [environment variables](https://docs.resin.io/management/env-vars/)
@@ -20,10 +35,9 @@ Variable Name | Value | Description | Device-specific
 
 Apply the above settings in the "Fleet Configuration" panel (if applying it for the all devices withing your application), or "Device Configuration" panel (if applying it for a single device).
 
-
 ## License
 
-Copyright 2016 Resinio Ltd.
+Copyright 2016-2019 Balena Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ remotely control your 3d-printer with [octoprint](https://github.com/foosel/Octo
   - [TouchUI](https://plugins.octoprint.org/plugins/touchui/)
   - [Preheat](https://plugins.octoprint.org/plugins/preheat/)
   - [DisplayProgress](https://plugins.octoprint.org/plugins/displayprogress/)
+  - [Cost Estimation](https://plugins.octoprint.org/plugins/costestimation/)
   - [BedLevelVisualizer](https://plugins.octoprint.org/plugins/bedlevelvisualizer/)
   - [Floating Navbar](https://plugins.octoprint.org/plugins/floatingnavbar/)
   - [Navbar Temperature](https://plugins.octoprint.org/plugins/navbartemp/)

--- a/app/start.sh
+++ b/app/start.sh
@@ -6,9 +6,10 @@ modprobe bcm2835-v4l2 >/dev/null 2>&1 || true
 # Start haproxy
 service haproxy start >/dev/null 2>&1 || true
 
+export LD_LIBRARY_PATH="/usr/src/app/mjpg-streamer/mjpg-streamer-experimental"
+
 # start picam stream
-cd /usr/src/app/mjpg-streamer/mjpg-streamer-experimental/ \
-  && ./mjpg_streamer -i "./input_uvc.so -y" -o "./output_http.so"  &
+cd /usr/src/app/mjpg-streamer/mjpg-streamer-experimental/ && ./mjpg_streamer -i "input_raspicam.so -x 1280 -y 720 -fps 15 -vf -hf -quality 90" -o "output_http.so -w `pwd`/www" -b
 
 # start Octoprint
-octoprint --iknowwhatimdoing --port=5000 --basedir /data
+octoprint serve --iknowwhatimdoing --port=5000 --basedir /data

--- a/app/start.sh
+++ b/app/start.sh
@@ -9,7 +9,7 @@ service haproxy start >/dev/null 2>&1 || true
 export LD_LIBRARY_PATH="/usr/src/app/mjpg-streamer/mjpg-streamer-experimental"
 
 # start picam stream
-cd /usr/src/app/mjpg-streamer/mjpg-streamer-experimental/ && ./mjpg_streamer -i "input_raspicam.so -x 1280 -y 720 -fps 15 -vf -hf -quality 90" -o "output_http.so -w `pwd`/www" -b
+cd /usr/src/app/mjpg-streamer/mjpg-streamer-experimental/ && ./mjpg_streamer -i "input_raspicam.so" -o "output_http.so -w `pwd`/www" -b
 
 # start Octoprint
 octoprint serve --iknowwhatimdoing --port=5000 --basedir /data

--- a/app/start.sh
+++ b/app/start.sh
@@ -6,6 +6,7 @@ modprobe bcm2835-v4l2 >/dev/null 2>&1 || true
 # Start haproxy
 service haproxy start >/dev/null 2>&1 || true
 
+# Make sure mpjg-streamer can find the plugins
 export LD_LIBRARY_PATH="/usr/src/app/mjpg-streamer/mjpg-streamer-experimental"
 
 # start picam stream


### PR DESCRIPTION
As this repo was outdated, I updated this with the following changes:

- Using Debian Jessie
- Added extra dependencies to make Octolapse work
- Added other plugins (UI, Octolapse)
- Updated README

Tested succesfully on a RPI3 running balenaOS 2.36.0+rev2 production (Supervisor 9.15.0). Image size will be approx 720 Mb after build

P.S. Not entirely sure if we need raspicam.so (this made it work for me) instead of input_uvc.so in start.sh