### PR TITLE
don't rely on pre-built image, but install OctoPrint from pip

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build: ./octoprint
     restart: always
     volumes:
-      - 'octoprint-data:/data'
+      - 'octoprint-data:/root/.octoprint'
     privileged: true
     ports:
       - '80:5000'

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -1,11 +1,7 @@
-FROM debian
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:build
 
-RUN apt-get update && apt-get install -y \
-  python3 python3-pip \
-  && rm -rf /var/lib/apt/lists/*
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN python -m pip install virtualenv
-WORKDIR /app
+ENV UDEV=1
+
 RUN python -m pip install --no-cache-dir OctoPrint
 
 RUN python -m pip install --no-cache-dir \
@@ -15,6 +11,6 @@ RUN python -m pip install --no-cache-dir \
     "https://github.com/eyal0/OctoPrint-PrintTimeGenius/archive/master.zip"
 
 # Seed the initial config.yaml
-COPY ./config.yaml /data/config.yaml
+COPY ./config.yaml /root/.octoprint/config.yaml
 
 CMD ["octoprint","serve","--iknowwhatimdoing","--host","0.0.0.0"]

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -1,6 +1,14 @@
-FROM --platform=linux/arm/v7 nunofgs/octoprint:master-alpine
+FROM debian
 
-RUN PYTHONUSERBASE=/usr/local/ pip install --no-cache-dir \
+RUN apt-get update && apt-get install -y \
+  python3 python3-pip \
+  && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN python -m pip install virtualenv
+WORKDIR /app
+RUN python -m pip install --no-cache-dir OctoPrint
+
+RUN python -m pip install --no-cache-dir \
     "https://github.com/marian42/octoprint-preheat/archive/master.zip" \
     "https://github.com/OllisGit/OctoPrint-DisplayLayerProgress/releases/latest/download/master.zip" \
     "https://github.com/malnvenshorn/OctoPrint-FilamentManager/archive/master.zip" \


### PR DESCRIPTION
The image we based on before was outdated and not based on a balena base image. This gives the most uptodate version and easy update capabilities